### PR TITLE
Add codecov integration

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,11 +62,12 @@ jobs:
     - name: Run tests with coverage
       env:
         SECRET_KEY: ${{ secrets.SECRET_KEY || 'ci-test-secret-key-not-for-production' }}
-      run: pytest tests/ -v --cov=project --cov-report=xml
+      run: pytest tests/ -v --cov=project --cov-branch --cov-report=xml
 
     - name: Upload coverage to Codecov
       # codecov/codecov-action@v6 (57e3a136b779b570ffcdbf80b3bdc90e7fab3de2)
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
         fail_ci_if_error: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ line-ending = "auto"
 # ---------------------------------------------------------------------------
 [tool.coverage.run]
 source = ["project"]
+branch = true
 omit = ["tests/*", ".*venv*/*"]
 
 [tool.coverage.report]


### PR DESCRIPTION
# Issue
This pull request updates the test coverage reporting to include branch coverage and ensures the Codecov upload uses an explicit token. The changes also update the coverage configuration to track branch coverage in addition to line coverage.



# How was it fixed ?
**Test coverage improvements:**

* The test command in `.github/workflows/master.yml` now runs pytest with the `--cov-branch` flag, enabling branch coverage reporting.
* The coverage configuration in `pyproject.toml` now explicitly enables branch coverage by setting `branch = true`.

**CI/CD configuration:**

* The Codecov upload step now uses the `CODECOV_TOKEN` secret for authentication.

# How is it being tested ?


# Out of Scope

